### PR TITLE
reduce variables and use the invalidate api

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,13 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@1.1.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "linked": [
-    ["@prefresh/webpack", "@prefresh/core"],
-    ["@prefresh/nollup", "@prefresh/core"],
-    ["@prefresh/vite", "@prefresh/core"],
-    ["@prefresh/webpack", "@prefresh/utils"],
-    ["@prefresh/nollup", "@prefresh/utils"]
-  ],
+  "linked": [],
   "access": "restricted",
   "baseBranch": "master",
   "updateInternalDependencies": "patch"

--- a/.changeset/witty-cobras-sell.md
+++ b/.changeset/witty-cobras-sell.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/webpack': minor
+---
+
+Make use of the `module.hot.invalidate` API when it's available, this will replace a full window reload when errors are thrown.

--- a/packages/webpack/src/loader/runtime.js
+++ b/packages/webpack/src/loader/runtime.js
@@ -1,30 +1,36 @@
 /* globals __prefresh_utils__ */
 module.exports = function() {
-	const isCitizen = __prefresh_utils__.registerExports(module);
+	const isPrefreshComponent = __prefresh_utils__.registerExports(module);
 
-	if (module.hot && isCitizen) {
-		const moduleExports = __prefresh_utils__.getExports(module);
-		const m =
-			module.hot.data && module.hot.data.module && module.hot.data.module;
+	if (module.hot && isPrefreshComponent) {
+		const hotModuleExports = __prefresh_utils__.getExports(module);
+		const previousHotModuleExports =
+			module.hot.data && module.hot.data.moduleExports;
 
-		if (m) {
-			for (let i in moduleExports) {
-				const fn = moduleExports[i];
+		if (previousHotModuleExports) {
+			for (let i in hotModuleExports) {
 				try {
-					if (typeof fn === 'function') {
-						const oldExports = __prefresh_utils__.getExports(m);
-						if (i in oldExports) {
-							__prefresh_utils__.compareSignatures(oldExports[i], fn);
+					if (typeof hotModuleExports[i] === 'function') {
+						if (i in previousHotModuleExports) {
+							__prefresh_utils__.compareSignatures(
+								previousHotModuleExports[i],
+								hotModuleExports[i]
+							);
 						}
 					}
 				} catch (e) {
-					self.location.reload();
+					// Only available in newer webpack versions.
+					if (module.hot.invalidate) {
+						module.hot.invalidate();
+					} else {
+						self.location.reload();
+					}
 				}
 			}
 		}
 
 		module.hot.dispose(function(data) {
-			data.module = module;
+			data.moduleExports = __prefresh_utils__.getExports(module);
 		});
 
 		module.hot.accept(function errorRecovery() {


### PR DESCRIPTION
Reduces amount of allocated variables and uses the new [invalidate API](https://webpack.js.org/api/hot-module-replacement/#invalidate) instead of reloading when it's available.

Closes https://github.com/JoviDeCroock/prefresh/issues/29