### PR TITLE
Support vite better

### DIFF
--- a/.changeset/poor-pens-end.md
+++ b/.changeset/poor-pens-end.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/vite': minor
+---
+
+Support hook reloading by comparing signatures.

--- a/packages/snowpack/package.json
+++ b/packages/snowpack/package.json
@@ -22,7 +22,7 @@
 		"@prefresh/utils": "0.1.1"
 	},
 	"devDependencies": {
-		"cjyes": "^0.1.0",
+		"cjyes": "^0.3.0",
 		"preact": "^10.4.1",
 		"snowpack": "^2.0.0-beta.24"
 	},

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -26,7 +26,7 @@
 	"devDependencies": {
 		"cjyes": "^0.1.0",
 		"preact": "^10.4.1",
-		"vite": "^0.14.2"
+		"vite": "^0.16.0"
 	},
 	"peerDependencies": {
 		"preact": "^10.4.0",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -24,7 +24,7 @@
 		"react-refresh": "^0.8.2"
 	},
 	"devDependencies": {
-		"cjyes": "^0.1.0",
+		"cjyes": "^0.3.0",
 		"preact": "^10.4.1",
 		"vite": "^0.16.0"
 	},

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -18,7 +18,10 @@
 	},
 	"homepage": "https://github.com/JoviDeCroock/prefresh#readme",
 	"dependencies": {
-		"@prefresh/core": "0.5.0"
+		"@babel/core": "^7.9.6",
+		"@prefresh/core": "0.6.1",
+		"@prefresh/utils": "^0.1.1",
+		"react-refresh": "^0.8.2"
 	},
 	"devDependencies": {
 		"cjyes": "^0.1.0",

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -3,37 +3,65 @@ export default function prefreshPlugin() {
 	return {
 		transforms: [
 			{
-				as: 'js',
-				test(path, query) {
-					if (!/\.[tj]sx$/.test(path)) return false;
-					// @ts-ignore
-					this.path = path;
-					return true;
-				},
-				// todo: use isImport to ignore `/@modules` requests?
-				transform(code, isImport) {
-					// The module imports itself to get its current exports, avoiding the need for eval().
+				test: path => /\.(t|j)s(x)?$/.test(path),
+				transform(code, _, isBuild, path) {
+					if (
+						isBuild ||
+						process.env.NODE_ENV === 'production' ||
+						path.includes('@modules')
+					)
+						return code;
 
-					// @ts-ignore
-					const spec = JSON.stringify(this.path);
+					const spec = JSON.stringify(path);
 
-          // Note: prefresh *must* be injected prior to any VNodes being created!
-          // TODO: check whether or not we can use @prefresh/utils.isComponent to not bind
-          // custom hooks.
+					const result = require('@babel/core').transformSync(code, {
+						plugins: [require('react-refresh/babel')],
+						ast: false,
+						sourceMaps: false
+					});
+
 					return `
             import '@prefresh/core';
+            import { compareSignatures, isComponent } from '@prefresh/utils';
             import { hot } from 'vite/hmr';
             import * as __PSELF__ from ${spec};
-            ${code}
+
+            const prevRefreshReg = window.$RefreshReg$ || (() => {});
+            const prevRefreshSig = window.$RefreshSig$ || (() => {});
+
+            const module = {};
+            let hasComponents = false;
+
+            window.$RefreshReg$ = (type, id) => {
+              module[type.name] = type;
+              if (isComponent(type.name)) hasComponents = true;
+            }
+
+            window.$RefreshSig$ = () => {
+              let status = 'begin';
+              let savedType;
+              return (type, key, forceReset, getCustomHooks) => {
+                if (!savedType) savedType = type;
+                status = self.__PREFRESH__.sign(type || savedType, key, forceReset, getCustomHooks, status);
+              };
+            };
+
+            ${result.code}
+
             if (__DEV__) {
-              let a = 0;
-              hot.accept(m => {
-                try {
-                  if (!a++) for (let i in m) self.__PREFRESH__.replaceComponent(__PSELF__[i], m[i]);
-                } catch (e) {
-                  window.location.reload();
-                }
-              });
+              window.$RefreshReg$ = prevRefreshReg;
+              window.$RefreshSig$ = prevRefreshSig;
+              if (hasComponents) {
+                hot.accept((m) => {
+                  try {
+                    for (let i in m) {
+                      compareSignatures(module[i], m[i]);
+                    }
+                  } catch (e) {
+                    window.location.reload();
+                  }
+                });
+              }
             }
           `;
 				}

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -1,30 +1,11 @@
-const preparation = `
-const prevRefreshReg = window.$RefreshReg$ || (() => {});
-const prevRefreshSig = window.$RefreshSig$ || (() => {});
-`;
-
-const signatureRegistration = `
-window.$RefreshSig$ = () => {
-  let status = 'begin';
-  let savedType;
-  return (type, key, forceReset, getCustomHooks) => {
-    if (!savedType) savedType = type;
-    status = self.__PREFRESH__.sign(type || savedType, key, forceReset, getCustomHooks, status);
-  };
-};
-`;
-
-const cleanup = `
-window.$RefreshReg$ = prevRefreshReg;
-window.$RefreshSig$ = prevRefreshSig;
-`;
+import { transformSync } from '@babel/core';
 
 /** @returns {import('vite').Plugin} */
 export default function prefreshPlugin() {
 	return {
 		transforms: [
 			{
-				test: path => /\.(t|j)s$/.test(path),
+				test: path => /\.(t|j)s(x)?$/.test(path),
 				transform(code, _, isBuild, path) {
 					if (
 						isBuild ||
@@ -33,76 +14,58 @@ export default function prefreshPlugin() {
 					)
 						return code;
 
-					const result = require('@babel/core').transformSync(code, {
-						plugins: [require('react-refresh/babel')],
-						ast: false,
-						sourceMaps: false
-					});
+					const result = transform(code);
+					const shouldBind = result.code.includes('$RefreshReg$(');
 
 					return `
-            ${preparation}
+            ${
+							shouldBind
+								? `
+              import '@prefresh/core';
+              import { compareSignatures } from '@prefresh/utils';
+              import { hot } from 'vite/hmr';
+            `
+								: ''
+						}
 
-            window.$RefreshReg$ = (type, id) => {}
-
-            ${signatureRegistration}
-
-            ${result.code}
-
-            if (__DEV__) {
-              ${cleanup}
-            }
-          `;
-				}
-			},
-			{
-				test: path => /\.(t|j)sx$/.test(path),
-				transform(code, _, isBuild, path) {
-					if (
-						isBuild ||
-						process.env.NODE_ENV === 'production' ||
-						path.includes('@modules')
-					)
-						return code;
-
-					const spec = JSON.stringify(path);
-
-					const result = require('@babel/core').transformSync(code, {
-						plugins: [require('react-refresh/babel')],
-						ast: false,
-						sourceMaps: false
-					});
-
-					return `
-            import '@prefresh/core';
-            import { compareSignatures, isComponent } from '@prefresh/utils';
-            import { hot } from 'vite/hmr';
-            import * as __PSELF__ from ${spec};
-
-            ${preparation}
+            const prevRefreshReg = window.$RefreshReg$ || (() => {});
+            const prevRefreshSig = window.$RefreshSig$ || (() => {});
 
             const module = {};
-            let hasComponents = false;
 
             window.$RefreshReg$ = (type, id) => {
               module[type.name] = type;
-              if (isComponent(type.name)) hasComponents = true;
             }
 
-            ${signatureRegistration}
+            window.$RefreshSig$ = () => {
+              let status = 'begin';
+              let savedType;
+              return (type, key, forceReset, getCustomHooks) => {
+                if (!savedType) savedType = type;
+                status = self.__PREFRESH__.sign(type || savedType, key, forceReset, getCustomHooks, status);
+              };
+            };
 
             ${result.code}
 
             if (__DEV__) {
-              ${cleanup}
-              hot.accept((m) => {
-                try {
-                  for (let i in m) {
-                    compareSignatures(module[i], m[i]);
+              window.$RefreshReg$ = prevRefreshReg;
+              window.$RefreshSig$ = prevRefreshSig;
+              ${
+								shouldBind
+									? `
+                hot.accept((m) => {
+                  try {
+                    for (let i in m) {
+                      compareSignatures(module[i], m[i]);
+                    }
+                  } catch (e) {
+                    window.location.reload();
                   }
-                } catch (e) {
-                  window.location.reload();
-                }
-              });
+                });
+              `
+									: ''
+							}
             }
           `;
 				}
@@ -110,3 +73,10 @@ export default function prefreshPlugin() {
 		]
 	};
 }
+
+const transform = code =>
+	transformSync(code, {
+		plugins: [require('react-refresh/babel')],
+		ast: false,
+		sourceMaps: false
+	});

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -19,8 +19,6 @@ export default function prefreshPlugin() {
 					});
 
 					return `
-            import * as __PSELF__ from ${spec};
-
             const prevRefreshReg = window.$RefreshReg$ || (() => {});
             const prevRefreshSig = window.$RefreshSig$ || (() => {});
 

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -3,7 +3,49 @@ export default function prefreshPlugin() {
 	return {
 		transforms: [
 			{
-				test: path => /\.(t|j)s(x)?$/.test(path),
+				test: path => /\.(t|j)s$/.test(path),
+				transform(code, _, isBuild, path) {
+					if (
+						isBuild ||
+						process.env.NODE_ENV === 'production' ||
+						path.includes('@modules')
+					)
+						return code;
+
+					const result = require('@babel/core').transformSync(code, {
+						plugins: [require('react-refresh/babel')],
+						ast: false,
+						sourceMaps: false
+					});
+
+					return `
+            import * as __PSELF__ from ${spec};
+
+            const prevRefreshReg = window.$RefreshReg$ || (() => {});
+            const prevRefreshSig = window.$RefreshSig$ || (() => {});
+
+            window.$RefreshReg$ = (type, id) => {}
+
+            window.$RefreshSig$ = () => {
+              let status = 'begin';
+              let savedType;
+              return (type, key, forceReset, getCustomHooks) => {
+                if (!savedType) savedType = type;
+                status = self.__PREFRESH__.sign(type || savedType, key, forceReset, getCustomHooks, status);
+              };
+            };
+
+            ${result.code}
+
+            if (__DEV__) {
+              window.$RefreshReg$ = prevRefreshReg;
+              window.$RefreshSig$ = prevRefreshSig;
+            }
+          `;
+				}
+			},
+			{
+				test: path => /\.(t|j)sx$/.test(path),
 				transform(code, _, isBuild, path) {
 					if (
 						isBuild ||
@@ -51,17 +93,15 @@ export default function prefreshPlugin() {
             if (__DEV__) {
               window.$RefreshReg$ = prevRefreshReg;
               window.$RefreshSig$ = prevRefreshSig;
-              if (hasComponents) {
-                hot.accept((m) => {
-                  try {
-                    for (let i in m) {
-                      compareSignatures(module[i], m[i]);
-                    }
-                  } catch (e) {
-                    window.location.reload();
+              hot.accept((m) => {
+                try {
+                  for (let i in m) {
+                    compareSignatures(module[i], m[i]);
                   }
-                });
-              }
+                } catch (e) {
+                  window.location.reload();
+                }
+              });
             }
           `;
 				}

--- a/yarn.lock
+++ b/yarn.lock
@@ -771,34 +771,34 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@vue/compiler-core@3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.0-beta.12.tgz#1d9bfeeedd7fb9fd8181e762b8c42568e9caf69c"
-  integrity sha512-+UjGiEo/RLx7yaAUfSuhZCvXypV85CKgVERXvtL/yOLd+3Y37Z7d5Qwnsej3S4NPvhvHNUFplhU1P1LOucw0pg==
+"@vue/compiler-core@3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.0-beta.14.tgz#69019b5c3da8335e6d83f81b37648caf120dbacd"
+  integrity sha512-VZarslk2r0E8V9Iuu24LPOWuomWV8KgTp3Pmie6Ys+LnIk+G/hme9BwC2jZgmqgF+adwcfmUC5BTi/KbhRVeIw==
   dependencies:
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
-    "@vue/shared" "3.0.0-beta.12"
+    "@vue/shared" "3.0.0-beta.14"
     estree-walker "^0.8.1"
     source-map "^0.6.1"
 
-"@vue/compiler-dom@3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.0-beta.12.tgz#f455898b96d421d71c808ca35b8349504a2f7ffd"
-  integrity sha512-HEirNEGczvMep3suCZO91q/1x5wEO0y0MvZJ51HJL2UZBSUjBSp/8ilBVWpOoOYC6mYVoxEIm1Jv9AoSsOipzQ==
+"@vue/compiler-dom@3.0.0-beta.14", "@vue/compiler-dom@^3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.0-beta.14.tgz#2ea1c165e06e9630e687a7a5cbde4e8b20b064ac"
+  integrity sha512-wZ2uWo4jvAGD5FPNZYMOxpKEDigLcoPvOGhIAv8H4B6ltDyW54Zfc4RrW5MopJqEcHDDZMpcgGcFN5Qa09sLOg==
   dependencies:
-    "@vue/compiler-core" "3.0.0-beta.12"
-    "@vue/shared" "3.0.0-beta.12"
+    "@vue/compiler-core" "3.0.0-beta.14"
+    "@vue/shared" "3.0.0-beta.14"
 
-"@vue/compiler-sfc@^3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.0.0-beta.12.tgz#ed93aa0f07d5d099cea7582118e05fbb7c77b1c6"
-  integrity sha512-YtX7SJdk68eKPwcL0u515MjOerMSao5UrM0EtL5zxLlQUiokmqxddxALEM28C62CoUonAWr8CWqnb262u0DBoA==
+"@vue/compiler-sfc@^3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.0.0-beta.14.tgz#3984416c0ed1bbdfbeee9d33c8a2c1152ed00770"
+  integrity sha512-pS/vTlLWBEkyyA2oZBQHqqObaLEy25BKX9LzNphDBC+zKRufGQEObecwSbJK2QGdu8/bzxI3sAJvBlPm8ZmDOA==
   dependencies:
-    "@vue/compiler-core" "3.0.0-beta.12"
-    "@vue/compiler-dom" "3.0.0-beta.12"
-    "@vue/compiler-ssr" "3.0.0-beta.12"
-    "@vue/shared" "3.0.0-beta.12"
+    "@vue/compiler-core" "3.0.0-beta.14"
+    "@vue/compiler-dom" "3.0.0-beta.14"
+    "@vue/compiler-ssr" "3.0.0-beta.14"
+    "@vue/shared" "3.0.0-beta.14"
     consolidate "^0.15.1"
     hash-sum "^2.0.0"
     lru-cache "^5.1.1"
@@ -808,42 +808,42 @@
     postcss-selector-parser "^6.0.2"
     source-map "^0.6.1"
 
-"@vue/compiler-ssr@3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.0.0-beta.12.tgz#ba935628ca2c917e8114b24d95ebfaf345136eb1"
-  integrity sha512-e1HRCQn5wCOQpcjLWUMyWPzKQSFmn2Sn0ZuhXPBsK1IlR1ElFOK6EC/EUHGwz3piFWZpuqpEWX7+0B9AYWNJAg==
+"@vue/compiler-ssr@3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.0.0-beta.14.tgz#e5a0dc1afcaf4f110e2e447b41bb3d8172e3e3e9"
+  integrity sha512-u5NquoX/EgmY40PICZoOA+CBzQNkYW0IhrTiqzN2BivUAO4PM3L0jesAFTbVX5CQ6eGJn1jGjBuuEks2IkJzsw==
   dependencies:
-    "@vue/compiler-dom" "3.0.0-beta.12"
-    "@vue/shared" "3.0.0-beta.12"
+    "@vue/compiler-dom" "3.0.0-beta.14"
+    "@vue/shared" "3.0.0-beta.14"
 
-"@vue/reactivity@3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.0-beta.12.tgz#33e8c3845dc663967c85217316f831a0153c40dc"
-  integrity sha512-ZgqLVADzwgFvm+Jf12bfzesvV3wcZXfM6JmryZ2BrWvkGS+Xo0A4oOcnsB4Tmqw5lemdYYkoleup02ChzvRlMg==
+"@vue/reactivity@3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.0-beta.14.tgz#a041ec24ce2e545583a6a1a42774311c16870a91"
+  integrity sha512-csqLljnM+8OBBAyzeUXGIYJhhph0DLOsHQwJGmz7uc342taW6XSi4MXaLk5MRiigunfmXxEswJGziwsh+4YP3g==
   dependencies:
-    "@vue/shared" "3.0.0-beta.12"
+    "@vue/shared" "3.0.0-beta.14"
 
-"@vue/runtime-core@3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.0-beta.12.tgz#f35fa386c319e13da682e58f171e25c2376ec865"
-  integrity sha512-qcgfp5VJCuObGIYPoust7l3hZONHfgJfVeVYPjaKi+asjlYwdmjTRExUahhjuHvkLdSGRY+qckS3Adga7kyMjg==
+"@vue/runtime-core@3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.0-beta.14.tgz#4f8162befd6ad1ac55cc6c142edc8301b090658a"
+  integrity sha512-5WKNMd7lX0vdSMeNd1cF0VhM+N+kXicSXKKZtTfQLUfZt1gLuE3nlBhv1PqjGf79zXw5lQLzz6XoUY1i52rEkA==
   dependencies:
-    "@vue/reactivity" "3.0.0-beta.12"
-    "@vue/shared" "3.0.0-beta.12"
+    "@vue/reactivity" "3.0.0-beta.14"
+    "@vue/shared" "3.0.0-beta.14"
 
-"@vue/runtime-dom@3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.0-beta.12.tgz#f9c0f02fb2152727ec0746517ae5ab08513d00e8"
-  integrity sha512-1fyDeKKX2KMZbMmxn9a/QzwYSlbzZlGz3Iy9iss/WbFFK9hNtAEWY6x4iwtw7/vJ00EE8OOMgHX3ki9fNNqSqw==
+"@vue/runtime-dom@3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.0-beta.14.tgz#080e9dd48a95da639f9fcc6d70a2d9620aec6ab8"
+  integrity sha512-nwHvG+IsO0Ttl39NPvQKX2vv5H4XWZVzZCX1rqEIBP3llHyyB9dMrNSPcw54YlPGrEuCwBxVDokHG4CSeVEdtg==
   dependencies:
-    "@vue/runtime-core" "3.0.0-beta.12"
-    "@vue/shared" "3.0.0-beta.12"
+    "@vue/runtime-core" "3.0.0-beta.14"
+    "@vue/shared" "3.0.0-beta.14"
     csstype "^2.6.8"
 
-"@vue/shared@3.0.0-beta.12":
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.0-beta.12.tgz#cb7a2bb047919d2c944bf822032b0a8aa869ba1d"
-  integrity sha512-cA0DD3VFGYI76lbM90fAYXNJ9EmDNsm1tthO4FIY18DwziZKJWCfQBhEfHQd2skHcTE4OqH5eBxgsKEdn/LuGQ==
+"@vue/shared@3.0.0-beta.14":
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.0-beta.14.tgz#886afe5c233a5b255c186142324c40f114958af5"
+  integrity sha512-mnK5teJMLzsBE56Kys+uiyR/jAl1kbokHZ++MnlP7ls9icPqZ/QQE/VTDl3QJ7IHteS2VR6ytAz/Aa/4Dpv/ew==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -2308,7 +2308,7 @@ debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
+debug@^3.0.0, debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -2676,15 +2676,15 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild@^0.2.6:
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.2.11.tgz#e6676fe15308e467be10eb4f534b60e1ed74e25a"
-  integrity sha512-T614oyicETVZemGY5Km9y2TPepyVVqg/VEpZRrCoKjw5DTF8IuSyWzIKB/tw0G/brlgQtXBetwAKzBrPORCOtA==
-
 esbuild@^0.3.0:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.3.3.tgz#7791f4c8d7db77fe7fef304a7ed1e09749b24594"
   integrity sha512-RFl1rLwo8MPHjq1G2EfPYbt6a0cvi74H+sPzkiNPq9mkQJj2d1U78j+ukZMDayZah9MptCM0rDuxFC+WUi2xUQ==
+
+esbuild@^0.3.2:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.3.5.tgz#1e14911862d8b2bf6b0993e743071897186131fb"
+  integrity sha512-EJNiTWGdhppolWRhfTrqbK2PMVVcMGqBCGSbiW2jRvhDv9s4MqSMm/18d8L1q0IFyxPaTg/I0MRlSik9nLttrA==
 
 escape-html@^1.0.3:
   version "1.0.3"
@@ -3197,6 +3197,13 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+follow-redirects@^1.0.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.11.0.tgz#afa14f08ba12a52963140fe43212658897bc0ecb"
+  integrity sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==
+  dependencies:
+    debug "^3.0.0"
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3581,6 +3588,14 @@ http-errors@^1.6.3, http-errors@~1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
+http-errors@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.4.0.tgz#6c0242dea6b3df7afda153c71089b31c6e82aabf"
+  integrity sha1-bAJC3qaz33r9oVPHEImzHG6Cqr8=
+  dependencies:
+    inherits "2.0.1"
+    statuses ">= 1.2.1 < 2"
+
 http-errors@~1.6.2:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
@@ -3590,6 +3605,15 @@ http-errors@~1.6.2:
     inherits "2.0.3"
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
+
+http-proxy@^1.16.2:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
+  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
+  dependencies:
+    eventemitter3 "^4.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
 
 http2-wrapper@^1.0.0-beta.4.5:
   version "1.0.0-beta.4.6"
@@ -4091,6 +4115,11 @@ is-wsl@^2.1.1:
   dependencies:
     is-docker "^2.0.0"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -4277,6 +4306,14 @@ koa-etag@^3.0.0:
   dependencies:
     etag "^1.3.0"
     mz "^2.1.0"
+
+koa-proxies@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/koa-proxies/-/koa-proxies-0.11.0.tgz#43dde4260080f7cb0f284655f85cf654bbe9ec84"
+  integrity sha512-iXGRADBE0fM7g7AttNOlLZ/cCFKXeVMHbFJKIRb0dUCrSYXi02loyVSdBlKlBQ5ZfVKJLo9Q9FyqwVTp1poVVA==
+  dependencies:
+    http-proxy "^1.16.2"
+    path-match "^1.2.4"
 
 koa-send@^5.0.0:
   version "5.0.0"
@@ -4699,7 +4736,7 @@ mime-db@1.44.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
-mime-types@^2.1.18, mime-types@^2.1.26, mime-types@~2.1.24:
+mime-types@^2.1.18, mime-types@^2.1.26, mime-types@^2.1.27, mime-types@~2.1.24:
   version "2.1.27"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
@@ -5402,10 +5439,25 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
+path-match@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/path-match/-/path-match-1.2.4.tgz#a62747f3c7e0c2514762697f24443585b09100ea"
+  integrity sha1-pidH88fgwlFHYml/JEQ1hbCRAOo=
+  dependencies:
+    http-errors "~1.4.0"
+    path-to-regexp "^1.0.0"
+
 path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-to-regexp@^1.0.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -6162,6 +6214,11 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
 resolve-alpn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.0.0.tgz#745ad60b3d6aff4b4a48e01b8c0bdc70959e0e8c"
@@ -6285,10 +6342,10 @@ rollup-plugin-terser@^5.3.0:
     serialize-javascript "^2.1.2"
     terser "^4.6.2"
 
-rollup-plugin-vue@^6.0.0-alpha.10:
-  version "6.0.0-alpha.10"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0-alpha.10.tgz#0fbe33f2e3d9f13c392a1eef0c421aa9cc218bb6"
-  integrity sha512-10GOFWTGMrX0pkG4AlkiyElhpQi2bSGD/Zed8IycRmpf7vO8NRm5hf+KM+uLGeZjPck1NNnQoUf6kPYCZ0CZAA==
+rollup-plugin-vue@^6.0.0-beta.1:
+  version "6.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0-beta.1.tgz#6334f3d76867f761623ba34c54a34a58a8d7ed24"
+  integrity sha512-jML9JYr+ZMQ1xUfMSgNzJ5kcv0kM+js9DJNBrUmvp1Lhydx8X4b3VOtybr0Dch5V3hUeBdxtKQgopadBnY9axA==
   dependencies:
     debug "^4.1.1"
     hash-sum "^2.0.0"
@@ -6699,7 +6756,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@^1.5.0:
+"statuses@>= 1.2.1 < 2", "statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
@@ -7379,45 +7436,49 @@ vendors@^1.0.0:
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.4.tgz#e2b800a53e7a29b93506c3cf41100d16c4c4ad8e"
   integrity sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==
 
-vite@^0.14.2:
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-0.14.2.tgz#a87454b6ea2010a6a1e24156544c35935947c0d5"
-  integrity sha512-7Qt/l8ivLYDtwHHGRLnQDiPuCV0UIgoX/atmqIcchAW5h5ET+JqJQArmXpzNrm795GjxErh39IM7kLLvTMSlqg==
+vite@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-0.16.0.tgz#c27317b66c44685d4cd19c2dd81d7953ac5cad04"
+  integrity sha512-JBgdl2qwfcgGciBYo/duMqjuQEFaH/Fwx5rGeEMIz/DxsaHEjscK8xigYfzvZ+UVnoC+VtmnnTGW5RiP3SCkLg==
   dependencies:
     "@babel/parser" "^7.9.4"
+    "@rollup/plugin-commonjs" "~11.0.0"
     "@rollup/plugin-json" "^4.0.3"
     "@rollup/plugin-node-resolve" "^7.1.3"
     "@types/koa" "^2.11.3"
-    "@vue/compiler-sfc" "^3.0.0-beta.12"
+    "@vue/compiler-dom" "^3.0.0-beta.14"
+    "@vue/compiler-sfc" "^3.0.0-beta.14"
     brotli-size "^4.0.0"
     chalk "^4.0.0"
     chokidar "^3.3.1"
     cssnano "^4.1.10"
     debug "^4.1.1"
     es-module-lexer "^0.3.18"
-    esbuild "^0.2.6"
+    esbuild "^0.3.2"
+    etag "^1.8.1"
     execa "^4.0.1"
     fs-extra "^9.0.0"
     hash-sum "^2.0.0"
     koa "^2.11.0"
     koa-conditional-get "^2.0.0"
     koa-etag "^3.0.0"
+    koa-proxies "^0.11.0"
     koa-send "^5.0.0"
     koa-static "^5.0.0"
     lru-cache "^5.1.1"
     magic-string "^0.25.7"
+    mime-types "^2.1.27"
     minimist "^1.2.5"
     open "^7.0.3"
     ora "^4.0.4"
     postcss "^7.0.28"
     postcss-load-config "^2.1.0"
     postcss-modules "^2.0.0"
-    resolve-from "^5.0.0"
     rollup "^2.7.2"
     rollup-plugin-terser "^5.3.0"
-    rollup-plugin-vue "^6.0.0-alpha.10"
+    rollup-plugin-vue "^6.0.0-beta.1"
     slash "^3.0.0"
-    vue "^3.0.0-beta.12"
+    vue "^3.0.0-beta.14"
     ws "^7.2.3"
 
 vm-browserify@^1.0.1:
@@ -7425,14 +7486,14 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-vue@^3.0.0-beta.12:
-  version "3.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.0-beta.12.tgz#e72d1baeede285768d2df0f2b52dc79427f49419"
-  integrity sha512-4Y8LPplndYp48q1P8CSbG3Et/bPcMQB11edusA6SuIGmgrLdS4Ntdwpjtc9kglYHaY9/E/VTVjl4jAGqpAFR1w==
+vue@^3.0.0-beta.14:
+  version "3.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.0-beta.14.tgz#d2c8739e00c4a4a06b519c14c57d204c350c980c"
+  integrity sha512-0MH1g5O3zX8ijvZuiQTYFq3UwHxtj512I/wrMPQLVXwjqb+ILA+fooSpdz4xgUBBl5zN/K9xJIwbl23sv+Sn7A==
   dependencies:
-    "@vue/compiler-dom" "3.0.0-beta.12"
-    "@vue/runtime-dom" "3.0.0-beta.12"
-    "@vue/shared" "3.0.0-beta.12"
+    "@vue/compiler-dom" "3.0.0-beta.14"
+    "@vue/runtime-dom" "3.0.0-beta.14"
+    "@vue/shared" "3.0.0-beta.14"
 
 watchpack@^1.6.1:
   version "1.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,28 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
+"@babel/core@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.6.tgz#d9aa1f580abf3b2286ef40b6904d390904c63376"
+  integrity sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.9.6"
+    "@babel/helper-module-transforms" "^7.9.0"
+    "@babel/helpers" "^7.9.6"
+    "@babel/parser" "^7.9.6"
+    "@babel/template" "^7.8.6"
+    "@babel/traverse" "^7.9.6"
+    "@babel/types" "^7.9.6"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.6.tgz#5408c82ac5de98cda0d77d8124e99fa1f2170a43"
@@ -35,10 +57,62 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-member-expression-to-functions@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz#659b710498ea6c1d9907e0c73f206eee7dadc24c"
+  integrity sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
+"@babel/helper-module-imports@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
+  integrity sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
+"@babel/helper-module-transforms@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz#43b34dfe15961918707d247327431388e9fe96e5"
+  integrity sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.8.3"
+    "@babel/helper-replace-supers" "^7.8.6"
+    "@babel/helper-simple-access" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/template" "^7.8.6"
+    "@babel/types" "^7.9.0"
+    lodash "^4.17.13"
+
+"@babel/helper-optimise-call-expression@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz#7ed071813d09c75298ef4f208956006b6111ecb9"
+  integrity sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
 "@babel/helper-plugin-utils@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz#9ea293be19babc0f52ff8ca88b34c3611b208670"
   integrity sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
+
+"@babel/helper-replace-supers@^7.8.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz#03149d7e6a5586ab6764996cd31d6981a17e1444"
+  integrity sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.8.3"
+    "@babel/helper-optimise-call-expression" "^7.8.3"
+    "@babel/traverse" "^7.9.6"
+    "@babel/types" "^7.9.6"
+
+"@babel/helper-simple-access@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz#7f8109928b4dab4654076986af575231deb639ae"
+  integrity sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==
+  dependencies:
+    "@babel/template" "^7.8.3"
+    "@babel/types" "^7.8.3"
 
 "@babel/helper-split-export-declaration@^7.8.3":
   version "7.8.3"
@@ -51,6 +125,15 @@
   version "7.9.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
   integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
+
+"@babel/helpers@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.9.6.tgz#092c774743471d0bb6c7de3ad465ab3d3486d580"
+  integrity sha512-tI4bUbldloLcHWoRUMAj4g1bF313M/o6fBKhIsb3QnGVPwRm9JsNf/gqMkQ7zjqReABiffPV6RWj7hEglID5Iw==
+  dependencies:
+    "@babel/template" "^7.8.3"
+    "@babel/traverse" "^7.9.6"
+    "@babel/types" "^7.9.6"
 
 "@babel/highlight@^7.8.3":
   version "7.9.0"
@@ -88,7 +171,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.8.3":
+"@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
   integrity sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==
@@ -97,7 +180,7 @@
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
 
-"@babel/traverse@^7.7.0":
+"@babel/traverse@^7.7.0", "@babel/traverse@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.6.tgz#5540d7577697bf619cc57b92aa0f1c231a94f442"
   integrity sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==
@@ -112,7 +195,7 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.7.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.5", "@babel/types@^7.9.6":
+"@babel/types@^7.7.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0", "@babel/types@^7.9.5", "@babel/types@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.6.tgz#2c5502b427251e9de1bd2dff95add646d95cc9f7"
   integrity sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==
@@ -358,11 +441,6 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
-
-"@prefresh/core@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@prefresh/core/-/core-0.5.0.tgz#119da56977cba45d5d7d4eaf99d0394bb9296c9a"
-  integrity sha512-1omCRCn7Jmv28DdgydMOoOuQFDaccbHx9EItJRAFNAxwvfr01/qi2fhVZa60tSV8HKEdOvBWvdky/l2sLNUSDQ==
 
 "@prefresh/core@0.6.0":
   version "0.6.0"
@@ -1881,6 +1959,13 @@ content-type@^1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
+convert-source-map@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
+  integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
+  dependencies:
+    safe-buffer "~5.1.1"
+
 cookies@~0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.8.0.tgz#1293ce4b391740a8406e3c9870e828c4b54f3f90"
@@ -3217,6 +3302,11 @@ generic-names@^2.0.1:
   dependencies:
     loader-utils "^1.1.0"
 
+gensync@^1.0.0-beta.1:
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
+  integrity sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
+
 get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
@@ -4080,6 +4170,13 @@ json5@^1.0.1:
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
+
+json5@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
+  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+  dependencies:
+    minimist "^1.2.5"
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -5899,6 +5996,11 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-refresh@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.2.tgz#24bb0858eac92b0d7b0dd561747f0c9fd6c60327"
+  integrity sha512-n8GXxo3DwM2KtFEL69DAVhGc4A1THn2qjmfvSo3nze0NLCoPbywazeJPqdp0RdSGLmyhQzeyA+XPXOobbYlkzg==
+
 read-pkg-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07"
@@ -6093,7 +6195,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.9.0:
+resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.3.2, resolve@^1.9.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1752,10 +1752,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-cjyes@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/cjyes/-/cjyes-0.1.0.tgz#97087c5aeb1bc5c0e0480e3683776a3fb09e9f5e"
-  integrity sha512-X+8iwqwiqY4DCYr3GO/uQt1ImiDgDA2K29AJo8pQRAVxh2g2A1QMqnQfg7Q53VityIt5Cm3BKqrtCG+aU98dlQ==
+cjyes@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/cjyes/-/cjyes-0.3.0.tgz#5f17e5f3c58e8c18ccde939ec10546b80d907c96"
+  integrity sha512-CzVtDdOnA22ytUHsjcnbpCJHO94ofxq0wJ242xfFiSUbpdbdcQYQhPmMRYjYLoFo1sz3ivCTyCvMDeEc9A+IdQ==
   dependencies:
     es-module-lexer "^0.3.18"
     magic-string "^0.25.7"


### PR DESCRIPTION
This brings some improvements to the way we're supporting `vite`, one crucial missing thing is we can't support custom-hooks seemless reload since vite is missing [bubbling HMR](https://github.com/pikapkg/esm-hmr/issues/6)

Closes https://github.com/JoviDeCroock/prefresh/issues/21