### PR TITLE
(vite) - update for vite 0.17 hmr api change

### DIFF
--- a/.changeset/gold-toys-yell.md
+++ b/.changeset/gold-toys-yell.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/vite': minor
+---
+
+upgrade for vite 0.17 compatibility

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -26,10 +26,10 @@
 	"devDependencies": {
 		"cjyes": "0.3.1",
 		"preact": "^10.4.1",
-		"vite": "^0.16.1"
+		"vite": "^0.17.0"
 	},
 	"peerDependencies": {
 		"preact": "^10.4.0",
-		"vite": "^0.16.1"
+		"vite": "^0.17.0"
 	}
 }

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -23,7 +23,6 @@ export default function prefreshPlugin() {
 								? `
               import '@prefresh/core';
               import { compareSignatures } from '@prefresh/utils';
-              import { hot } from 'vite/hmr';
             `
 								: ''
 						}
@@ -48,13 +47,13 @@ export default function prefreshPlugin() {
 
             ${result.code}
 
-            if (__DEV__) {
+            if (import.meta.hot) {
               window.$RefreshReg$ = prevRefreshReg;
               window.$RefreshSig$ = prevRefreshSig;
               ${
 								shouldBind
 									? `
-                hot.accept((m) => {
+                import.meta.hot.accept((m) => {
                   try {
                     for (let i in m) {
                       compareSignatures(module[i], m[i]);


### PR DESCRIPTION
The example isn't updated because it needs to wait until `@prefresh/vite` publishes a new version.