### PR TITLE
(core) - handle async errors

### DIFF
--- a/.changeset/good-kiwis-behave.md
+++ b/.changeset/good-kiwis-behave.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/core': patch
+---
+
+Handle async errors in nested components

--- a/packages/core/src/constants.js
+++ b/packages/core/src/constants.js
@@ -6,3 +6,5 @@ export const EFFECTS_LIST = '__h';
 export const RERENDER_COUNT = '__r';
 export const CATCH_ERROR_OPTION = '__e';
 export const COMPONENT_DIRTY = '__d';
+export const VNODE_DOM = '__e';
+export const VNODE_CHILDREN = '__k';

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -11,7 +11,9 @@ import {
 	NAMESPACE,
 	HOOKS_LIST,
 	EFFECTS_LIST,
-	COMPONENT_HOOKS
+	COMPONENT_HOOKS,
+	VNODE_DOM,
+	VNODE_CHILDREN
 } from './constants';
 import { computeKey } from './computeKey';
 import { vnodesForComponent } from './runtime/vnodesForComponent';
@@ -84,6 +86,7 @@ function replaceComponent(OldType, NewType, resetHookState) {
 				}
 			} catch (e) {
 				/* Functional component */
+				vnode[VNODE_COMPONENT].constructor = NewType;
 			}
 
 			if (resetHookState) {
@@ -91,6 +94,13 @@ function replaceComponent(OldType, NewType, resetHookState) {
 					[HOOKS_LIST]: [],
 					[EFFECTS_LIST]: []
 				};
+			}
+
+			if (
+				(vnode[VNODE_DOM] && !document.contains(vnode[VNODE_DOM])) ||
+				(!vnode[VNODE_DOM] && !vnode[VNODE_CHILDREN])
+			) {
+				location.reload();
 			}
 
 			Component.prototype.forceUpdate.call(vnode[VNODE_COMPONENT]);

--- a/packages/core/src/runtime/debounceRendering.js
+++ b/packages/core/src/runtime/debounceRendering.js
@@ -12,6 +12,7 @@ options.debounceRendering = process => {
 		try {
 			process();
 		} catch (e) {
+			console.log('has count', process[RERENDER_COUNT]);
 			process[RERENDER_COUNT] = 0;
 			throw e;
 		}

--- a/packages/core/src/runtime/debounceRendering.js
+++ b/packages/core/src/runtime/debounceRendering.js
@@ -12,7 +12,6 @@ options.debounceRendering = process => {
 		try {
 			process();
 		} catch (e) {
-			console.log('has count', process[RERENDER_COUNT]);
 			process[RERENDER_COUNT] = 0;
 			throw e;
 		}


### PR DESCRIPTION
When we for instance have

```
const LazyThrow = lazy(() => import('./x');

const Component = () => (
  <Suspense><LazyThrow /></Suspense>
)
```

We can't really recover efficiently so we force a reload when either we have a dom-node that isn't in the dom. Or we have no dom-node and no children.

The first measure counteracts Suspense where we hold the dom in memory and it will be available on the vnode. The latter is for the traditional AsyncRoute solutions where it will output `null` as _dom which is a valid value, but if it was from a successfull render we'd see children attached with [null]