### PR TITLE
Fix core

### DIFF
--- a/.changeset/perfect-students-confess.md
+++ b/.changeset/perfect-students-confess.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/core': patch
+---
+
+Add "default" to the export map to support CJS modules requiring core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,8 @@
 	"main": "src/index.js",
 	"exports": {
 		".": {
-			"import": "./src/index.js"
+			"import": "./src/index.js",
+			"default": "./src/index.js"
 		},
 		"./package.json": "./package.json",
 		"./": "./"


### PR DESCRIPTION
Fixes: https://github.com/JoviDeCroock/prefresh/issues/71

Because `@prefresh/next` is a CJS import requiring an `ESM` dependency it fails, this however shouldn't be an issue since it's not really used in the code only for bundler injection so it's safe to just make this a main tag.

In the future we could use `microbundle` to make a valid CJS export.