### PR TITLE
(vite) - Skip transforming node_modules

### DIFF
--- a/.changeset/hungry-rings-reflect.md
+++ b/.changeset/hungry-rings-reflect.md
@@ -1,5 +1,5 @@
 ---
-'@prefresh/vite': minor
+'@prefresh/vite': patch
 ---
 
 Skip transforming node_modules

--- a/.changeset/hungry-rings-reflect.md
+++ b/.changeset/hungry-rings-reflect.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/vite': minor
+---
+
+Skip transforming node_modules

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -10,7 +10,7 @@ export default function prefreshPlugin() {
 					if (
 						isBuild ||
 						process.env.NODE_ENV === 'production' ||
-						path.includes('@modules')
+						path.includes('node_modules')
 					)
 						return code;
 

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -10,7 +10,8 @@ export default function prefreshPlugin() {
 					if (
 						isBuild ||
 						process.env.NODE_ENV === 'production' ||
-						path.includes('node_modules')
+						path.includes('node_modules') ||
+            path.includes('@modules')
 					)
 						return code;
 


### PR DESCRIPTION
vite `1.0.0-beta.12` now resolves full path for transforms during dev.
