### PR TITLE
handle non-exported components

### DIFF
--- a/.changeset/modern-radios-hide.md
+++ b/.changeset/modern-radios-hide.md
@@ -1,0 +1,11 @@
+---
+'@prefresh/core': minor
+'@prefresh/next': minor
+'@prefresh/nollup': minor
+'@prefresh/snowpack': minor
+'@prefresh/utils': minor
+'@prefresh/vite': minor
+'@prefresh/webpack': minor
+---
+
+Handle non-exported components correctly

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -135,7 +135,6 @@ self[NAMESPACE] = {
 				type
 			});
 		}
-
 	},
 	getPendingUpdates: () => pendingUpdates,
 	flush: () => {

--- a/packages/next/src/loader/runtime.js
+++ b/packages/next/src/loader/runtime.js
@@ -8,8 +8,8 @@ module.exports = function() {
 			module.hot.data && module.hot.data.moduleExports;
 
 		if (previousHotModuleExports) {
-			for (let i in hotModuleExports) {
-				try {
+			try {
+				for (let i in hotModuleExports) {
 					if (typeof hotModuleExports[i] === 'function') {
 						if (i in previousHotModuleExports) {
 							__prefresh_utils__.compareSignatures(
@@ -18,17 +18,7 @@ module.exports = function() {
 							);
 						}
 					}
-				} catch (e) {
-					// Only available in newer webpack versions.
-					if (module.hot.invalidate) {
-						module.hot.invalidate();
-					} else {
-						self.location.reload();
-					}
 				}
-			}
-
-			try {
 				__prefresh_utils__.flush();
 			} catch (e) {
 				// Only available in newer webpack versions.

--- a/packages/next/src/loader/runtime.js
+++ b/packages/next/src/loader/runtime.js
@@ -27,6 +27,17 @@ module.exports = function() {
 					}
 				}
 			}
+
+			try {
+				__prefresh_utils__.flush();
+			} catch (e) {
+				// Only available in newer webpack versions.
+				if (module.hot.invalidate) {
+					module.hot.invalidate();
+				} else {
+					self.location.reload();
+				}
+			}
 		}
 
 		module.hot.dispose(function(data) {

--- a/packages/next/src/utils/prefresh.js
+++ b/packages/next/src/utils/prefresh.js
@@ -1,4 +1,4 @@
-const { isComponent, compareSignatures } = require('@prefresh/utils');
+const { isComponent, compareSignatures, flush } = require('@prefresh/utils');
 
 // eslint-disable-next-line
 const getExports = m => m.exports || m.__proto__.exports;
@@ -44,5 +44,6 @@ const registerExports = m => {
 module.exports = Object.freeze({
 	compareSignatures,
 	getExports,
-	registerExports
+	registerExports,
+	flush
 });

--- a/packages/nollup/src/runtime.js
+++ b/packages/nollup/src/runtime.js
@@ -1,4 +1,4 @@
-import { isComponent, compareSignatures } from '@prefresh/utils';
+import { isComponent, compareSignatures, flush } from '@prefresh/utils';
 
 // eslint-disable-next-line
 const getExports = m => m.exports || m.__proto__.exports;
@@ -62,6 +62,12 @@ export function __$RefreshCheck$__(module) {
 				} catch (e) {
 					self.location.reload();
 				}
+			}
+
+			try {
+				flush();
+			} catch (e) {
+				self.location.reload();
 			}
 		}
 

--- a/packages/nollup/src/runtime.js
+++ b/packages/nollup/src/runtime.js
@@ -50,21 +50,16 @@ export function __$RefreshCheck$__(module) {
 			module.hot.data && module.hot.data.module && module.hot.data.module;
 
 		if (m) {
-			for (let i in moduleExports) {
-				const fn = moduleExports[i];
-				try {
+			try {
+				for (let i in moduleExports) {
+					const fn = moduleExports[i];
 					if (typeof fn === 'function') {
 						const oldExports = getExports(m);
 						if (i in oldExports) {
 							compareSignatures(oldExports[i], fn);
 						}
 					}
-				} catch (e) {
-					self.location.reload();
 				}
-			}
-
-			try {
 				flush();
 			} catch (e) {
 				self.location.reload();

--- a/packages/snowpack/src/index.js
+++ b/packages/snowpack/src/index.js
@@ -1,4 +1,4 @@
-import { compareSignatures, isComponent } from '@prefresh/utils';
+import { compareSignatures, isComponent, flush } from '@prefresh/utils';
 
 export default function preactRefreshPlugin(config, pluginOptions) {
 	return {
@@ -15,6 +15,7 @@ export default function preactRefreshPlugin(config, pluginOptions) {
 
           const compareSignaturesForPrefreshment = ${compareSignatures.toString()};
           const shouldPrefreshBind = ${isComponent.toString()}
+          const flushUpdates = ${flush.toString()}
 
           const __module_exports__ = []
 
@@ -54,6 +55,8 @@ export default function preactRefreshPlugin(config, pluginOptions) {
                     }
                   }
                 }
+
+                flushUpdates();
                 $CurrentModule$ = module;
               } catch(e) {
                 import.meta.hot.invalidate();

--- a/packages/snowpack/src/index.js
+++ b/packages/snowpack/src/index.js
@@ -34,6 +34,9 @@ export default function preactRefreshPlugin(config, pluginOptions) {
 
           self.$RefreshReg$ = (type, id) => {
             __module_exports__.push(type.name);
+            self.__PREFRESH__.register(type, ${JSON.stringify(
+							urlPath
+						)} + " " + id);
           };
 
           ${contents}

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -14,6 +14,29 @@ export const compareSignatures = (prev, next) => {
 	}
 };
 
+export const flush = () => {
+	const pending = [...self.__PREFRESH__.getPendingUpdates()];
+	self.__PREFRESH__.flush();
+
+	if (pending.length > 0) {
+		pending.forEach(([oldType, newType]) => {
+			const prevSignature = self.__PREFRESH__.getSignature(oldType) || {};
+			const nextSignature = self.__PREFRESH__.getSignature(newType) || {};
+
+			if (
+				prevSignature.key !== nextSignature.key ||
+				self.__PREFRESH__.computeKey(prevSignature) !==
+					self.__PREFRESH__.computeKey(nextSignature) ||
+				nextSignature.forceReset
+			) {
+				self.__PREFRESH__.replaceComponent(oldType, newType, true);
+			} else {
+				self.__PREFRESH__.replaceComponent(oldType, newType, false);
+			}
+		});
+	}
+};
+
 export const isPreactCitizen = name =>
 	typeof name === 'string' &&
 	name[0](

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -36,6 +36,9 @@ export default function prefreshPlugin() {
 
               self.$RefreshReg$ = (type, id) => {
                 module[type.name] = type;
+                self.__PREFRESH__.register(type, ${JSON.stringify(
+									path
+								)} + " " + id);
               }
 
               self.$RefreshSig$ = () => {

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -11,7 +11,7 @@ export default function prefreshPlugin() {
 						isBuild ||
 						process.env.NODE_ENV === 'production' ||
 						path.includes('node_modules') ||
-            path.includes('@modules')
+						path.includes('@modules')
 					)
 						return code;
 
@@ -24,7 +24,7 @@ export default function prefreshPlugin() {
 					return {
 						code: `
             ${'import'} '@prefresh/vite/runtime';
-            ${'import'} { compareSignatures } from '@prefresh/vite/utils';
+            ${'import'} { compareSignatures, flushUpdates } from '@prefresh/vite/utils';
 
             let prevRefreshReg;
             let prevRefreshSig;
@@ -64,6 +64,8 @@ export default function prefreshPlugin() {
                       compareSignatures(module[i], m[i]);
                     }
                   }
+
+                  flushUpdates();
                 } catch (e) {
                   self.location.reload();
                 }

--- a/packages/vite/src/utils.js
+++ b/packages/vite/src/utils.js
@@ -1,2 +1,3 @@
-import { compareSignatures as compare } from '@prefresh/utils';
+import { compareSignatures as compare, flush } from '@prefresh/utils';
 export const compareSignatures = compare;
+export const flushUpdates = flush;

--- a/packages/webpack/example/src/App.js
+++ b/packages/webpack/example/src/App.js
@@ -1,12 +1,20 @@
 import { h } from 'preact';
 import { useCounter } from './useCounter';
 
-export function App(props) {
+const Comp1 = () => {
 	const [count, increment] = useCounter(0);
 	return (
 		<div>
-			<p>Count: {count}</p>
+			<p>Counter: {count}</p>
 			<button onClick={increment}>Increment</button>
+		</div>
+	);
+};
+
+export function App(props) {
+	return (
+		<div>
+			<Comp1 />
 		</div>
 	);
 }

--- a/packages/webpack/example/src/useCounter.js
+++ b/packages/webpack/example/src/useCounter.js
@@ -1,6 +1,6 @@
 import { useState } from 'preact/hooks';
 
 export const useCounter = initialValue => {
-	const [state, setState] = useState(initialValue || 0);
-	return [state, () => setState(state + 1)];
+	const [state, setState] = useState(0);
+	return [state, () => setState(state + 2)];
 };

--- a/packages/webpack/example/webpack.config.js
+++ b/packages/webpack/example/webpack.config.js
@@ -41,6 +41,11 @@ const makeConfig = () => {
 			path: path.resolve(__dirname, 'dist'),
 			publicPath: '/'
 		},
+		resolve: {
+			alias: {
+				preact: path.resolve(__dirname, 'node_modules', 'preact')
+			}
+		},
 		plugins,
 		module: {
 			rules: [

--- a/packages/webpack/src/loader/runtime.js
+++ b/packages/webpack/src/loader/runtime.js
@@ -8,8 +8,8 @@ module.exports = function() {
 			module.hot.data && module.hot.data.moduleExports;
 
 		if (previousHotModuleExports) {
-			for (let i in hotModuleExports) {
-				try {
+			try {
+				for (let i in hotModuleExports) {
 					if (typeof hotModuleExports[i] === 'function') {
 						if (i in previousHotModuleExports) {
 							__prefresh_utils__.compareSignatures(
@@ -18,17 +18,7 @@ module.exports = function() {
 							);
 						}
 					}
-				} catch (e) {
-					// Only available in newer webpack versions.
-					if (module.hot.invalidate) {
-						module.hot.invalidate();
-					} else {
-						self.location.reload();
-					}
 				}
-			}
-
-			try {
 				__prefresh_utils__.flush();
 			} catch (e) {
 				// Only available in newer webpack versions.

--- a/packages/webpack/src/loader/runtime.js
+++ b/packages/webpack/src/loader/runtime.js
@@ -27,6 +27,17 @@ module.exports = function() {
 					}
 				}
 			}
+
+			try {
+				__prefresh_utils__.flush();
+			} catch (e) {
+				// Only available in newer webpack versions.
+				if (module.hot.invalidate) {
+					module.hot.invalidate();
+				} else {
+					self.location.reload();
+				}
+			}
 		}
 
 		module.hot.dispose(function(data) {

--- a/packages/webpack/src/utils/prefresh.js
+++ b/packages/webpack/src/utils/prefresh.js
@@ -1,4 +1,4 @@
-const { isComponent, compareSignatures } = require('@prefresh/utils');
+const { isComponent, compareSignatures, flush } = require('@prefresh/utils');
 
 // eslint-disable-next-line
 const getExports = m => m.exports || m.__proto__.exports;
@@ -44,5 +44,6 @@ const registerExports = m => {
 module.exports = Object.freeze({
 	compareSignatures,
 	getExports,
-	registerExports
+	registerExports,
+	flush
 });


### PR DESCRIPTION
Fixes: #127
Fixes: #130

- [x] document thoughts around this
- [x] test all integrations
  - [x] webpack
  - [x] next.js
  - [x] vite
  - [x] snowpack
  - [x] nollup

The main problem being tackled here is the following:

```js
const Comp1 = () => {
	const [count, increment] = useCounter(0);
	return (
		<div>
			<p>Counter: {count}</p>
			<button onClick={increment}>Increment</button>
		</div>
	);
};

export function App(props) {
	return (
		<div>
			<Comp1 />
		</div>
	);
}
```

Comp1 isn't exported and thus not detected by our logic, we need to implement additional tracking. Luckily this can be done through the `register` method which allows us to identify a function by path --> function. We track these between registrations and compile an array of pending updates on our virtual dom. When we finish the first iteration (triggered by `module.hot.accept`) we check if there are some penidng updates we still need to flush, if this is the case we'll flush them.

In the near future I think we can fully dispose of `module.hot.accept` in favor of the flushing approach.