### PR TITLE
Add pipe to webpack peer dependency version

### DIFF
--- a/.changeset/clean-pears-rhyme.md
+++ b/.changeset/clean-pears-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/webpack': patch
+---
+
+Fix warning about unmet peer dependency webpack.

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -32,6 +32,6 @@
 	},
 	"peerDependencies": {
 		"preact": "^10.4.0",
-		"webpack": "^4.0.0 | ^5.0.0"
+		"webpack": "^4.0.0 || ^5.0.0"
 	}
 }


### PR DESCRIPTION
While bumping to the most recent version of `@prefresh/webpack` I got a warning from `pnpm` about an unmet peer dependency:

```
 WARN  @prefresh/webpack@1.0.0 requires a peer of webpack@^4.0.0 | ^5.0.0 but version 4.44.1 was installed.
```

I had a look at the [docs](https://docs.npmjs.com/files/package.json#dependencies) and it looked like a double pipe was required. I confirmed that with a `pnpmfile.js` entry to patch the peer dependency, and thought you might like a quick contrib to fix it in your library. I hope you don't mind... :)