### PR TITLE
webpack createTemplate undefined mainTemplate defensive programming

### DIFF
--- a/.changeset/moody-pigs-care.md
+++ b/.changeset/moody-pigs-care.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/webpack': patch
+---
+
+guard against mainTemplate missing in webpack4 build

--- a/packages/webpack/src/utils/createTemplate.js
+++ b/packages/webpack/src/utils/createTemplate.js
@@ -31,7 +31,11 @@ const afterModule = `
 `;
 
 function createRefreshTemplate(source, chunk, hash, mainTemplate) {
-	let filename = mainTemplate.outputOptions.filename;
+	let filename;
+	if (mainTemplate) {
+		filename = mainTemplate.outputOptions.filename;
+	}
+
 	if (typeof filename === 'function') {
 		filename = filename({
 			chunk,


### PR DESCRIPTION
Before:
prefresh webpack plugin failing dev build after babel upgrade 
 "@babel/core": "7.8.3" -> "7.11.1"

```
  ERROR in chunk main [entry]
    Cannot read property 'outputOptions' of undefined
```

After:

build completes
