### PR TITLE
Class components support

### DIFF
--- a/.changeset/neat-cameras-destroy.md
+++ b/.changeset/neat-cameras-destroy.md
@@ -1,0 +1,7 @@
+---
+'@prefresh/next': minor
+'@prefresh/nollup': minor
+'@prefresh/webpack': minor
+---
+
+Add class-component support

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
   "eslintIgnore": [
     "dist",
     "node_modules",
-    "test"
+    "test",
+    "temp"
   ],
   "prettier": {
     "singleQuote": true,

--- a/packages/next/src/loader/runtime.js
+++ b/packages/next/src/loader/runtime.js
@@ -3,11 +3,28 @@ module.exports = function() {
 	const isPrefreshComponent = __prefresh_utils__.registerExports(module);
 
 	if (module.hot && isPrefreshComponent) {
+		const hotModuleExports = __prefresh_utils__.getExports(module);
+
 		const previousHotModuleExports =
 			module.hot.data && module.hot.data.moduleExports;
 
 		if (previousHotModuleExports) {
 			try {
+				for (let i in hotModuleExports) {
+					if (typeof hotModuleExports[i] === 'function') {
+						if (i in previousHotModuleExports) {
+							if (
+								'prototype' in hotModuleExports[i] &&
+								hotModuleExports[i].prototype.render
+							) {
+								__prefresh_utils__.compareSignatures(
+									previousHotModuleExports[i],
+									hotModuleExports[i]
+								);
+							}
+						}
+					}
+				}
 				__prefresh_utils__.flush();
 			} catch (e) {
 				// Only available in newer webpack versions.

--- a/packages/next/src/utils/prefresh.js
+++ b/packages/next/src/utils/prefresh.js
@@ -1,4 +1,4 @@
-const { isComponent, flush } = require('@prefresh/utils');
+const { isComponent, flush, compareSignatures } = require('@prefresh/utils');
 
 // eslint-disable-next-line
 const getExports = m => m.exports || m.__proto__.exports;
@@ -44,5 +44,6 @@ const registerExports = m => {
 module.exports = Object.freeze({
 	getExports,
 	registerExports,
+	compareSignatures,
 	flush
 });

--- a/packages/nollup/src/runtime.js
+++ b/packages/nollup/src/runtime.js
@@ -1,4 +1,4 @@
-import { isComponent, flush } from '@prefresh/utils';
+import { isComponent, flush, compareSignatures } from '@prefresh/utils';
 
 // eslint-disable-next-line
 const getExports = m => m.exports || m.__proto__.exports;
@@ -45,11 +45,25 @@ export function __$RefreshCheck$__(module) {
 	const isCitizen = registerExports(module);
 
 	if (module.hot && isCitizen) {
+		const moduleExports = getExports(module);
 		const m =
 			module.hot.data && module.hot.data.module && module.hot.data.module;
 
 		if (m) {
 			try {
+				for (let i in moduleExports) {
+					if (typeof fn === 'function') {
+						const oldExports = getExports(m);
+						if (i in oldExports) {
+							if (
+								'prototype' in moduleExports[i] &&
+								moduleExports[i].prototype.render
+							) {
+								compareSignatures(oldExports[i], moduleExports[i]);
+							}
+						}
+					}
+				}
 				flush();
 			} catch (e) {
 				self.location.reload();

--- a/packages/webpack/src/loader/runtime.js
+++ b/packages/webpack/src/loader/runtime.js
@@ -3,11 +3,29 @@ module.exports = function() {
 	const isPrefreshComponent = __prefresh_utils__.registerExports(module);
 
 	if (module.hot && isPrefreshComponent) {
+		const hotModuleExports = __prefresh_utils__.getExports(module);
+
 		const previousHotModuleExports =
 			module.hot.data && module.hot.data.moduleExports;
 
 		if (previousHotModuleExports) {
 			try {
+				for (let i in hotModuleExports) {
+					if (typeof hotModuleExports[i] === 'function') {
+						if (i in previousHotModuleExports) {
+							if (
+								'prototype' in hotModuleExports[i] &&
+								hotModuleExports[i].prototype.render
+							) {
+								__prefresh_utils__.compareSignatures(
+									previousHotModuleExports[i],
+									hotModuleExports[i]
+								);
+							}
+						}
+					}
+				}
+
 				__prefresh_utils__.flush();
 			} catch (e) {
 				// Only available in newer webpack versions.

--- a/packages/webpack/src/utils/prefresh.js
+++ b/packages/webpack/src/utils/prefresh.js
@@ -1,4 +1,4 @@
-const { isComponent, flush } = require('@prefresh/utils');
+const { isComponent, flush, compareSignatures } = require('@prefresh/utils');
 
 // eslint-disable-next-line
 const getExports = m => m.exports || m.__proto__.exports;
@@ -44,5 +44,6 @@ const registerExports = m => {
 module.exports = Object.freeze({
 	getExports,
 	registerExports,
+	compareSignatures,
 	flush
 });

--- a/test/fixture/webpack/src/app.jsx
+++ b/test/fixture/webpack/src/app.jsx
@@ -1,5 +1,6 @@
 import { useCounter } from './useCounter'
 import { h } from 'preact'
+import { Class } from './class.jsx';
 
 function Test() {
   const [count, increment] = useCounter();
@@ -15,6 +16,7 @@ export function App(props) {
   return (
     <div>
       <Test />
+      <Class />
     </div>
   )
 }

--- a/test/fixture/webpack/src/app.jsx
+++ b/test/fixture/webpack/src/app.jsx
@@ -1,6 +1,6 @@
 import { useCounter } from './useCounter'
 import { h } from 'preact'
-import { Class } from './class.jsx';
+import { Greeting } from './greeting.jsx';
 
 function Test() {
   const [count, increment] = useCounter();
@@ -16,7 +16,7 @@ export function App(props) {
   return (
     <div>
       <Test />
-      <Class />
+      <Greeting />
     </div>
   )
 }

--- a/test/fixture/webpack/src/class.jsx
+++ b/test/fixture/webpack/src/class.jsx
@@ -1,0 +1,23 @@
+import { h, Component } from 'preact'
+
+export class Class extends Component {
+  constructor() {
+    this.state = { greeting: 'hi' };
+    this.setGreeting = this.setGreeting.bind(this);
+  }
+
+  setGreeting() {
+    this.setState({ greeting: 'bye' });
+  }
+
+  render() {
+    return (
+      <div>
+        <p className="class-text">I'm a class component</p>
+        <p className="greeting-text">{this.state.greeting}</p>
+        <button className="greeting-button" onClick={this.setGreeting}>set</p>
+      </div>
+    )
+  }
+
+}

--- a/test/fixture/webpack/src/class.jsx
+++ b/test/fixture/webpack/src/class.jsx
@@ -15,7 +15,7 @@ export class Class extends Component {
       <div>
         <p className="class-text">I'm a class component</p>
         <p className="greeting-text">{this.state.greeting}</p>
-        <button className="greeting-button" onClick={this.setGreeting}>set</p>
+        <button className="greeting-button" onClick={this.setGreeting}>set</button>
       </div>
     )
   }

--- a/test/fixture/webpack/src/greeting.jsx
+++ b/test/fixture/webpack/src/greeting.jsx
@@ -1,7 +1,8 @@
 import { h, Component } from 'preact'
 
-export class Class extends Component {
-  constructor() {
+export class Greeting extends Component {
+  constructor(props) {
+    super(props);
     this.state = { greeting: 'hi' };
     this.setGreeting = this.setGreeting.bind(this);
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -145,5 +145,45 @@ integrations.forEach(integration => {
 
 			await expectByPolling(() => getText(value), 'Count: 10');
 		});
+
+		if (integration === 'webpack') {
+			test('works for class-components', async () => {
+				const text = await page.$('.class-text');
+				await expectByPolling(() => getText(text), "I'm a class component");
+
+				await updateFile('src/class.jsx', content =>
+					content.replace(
+						"I'm a class component",
+						"I'm a reloaded class component"
+					)
+				);
+				await timeout(1000);
+
+				await expectByPolling(
+					() => getText(value),
+					"I'm a reloaded class component"
+				);
+			});
+
+			test('can change methods', async () => {
+				const text = await page.$('.greeting-text');
+				const button = await page.$('.greeting-button');
+				await expectByPolling(() => getText(text), 'hi');
+
+				await button.click();
+				await expectByPolling(() => getText(text), 'bye');
+
+				await updateFile('src/class.jsx', content =>
+					content.replace(
+						"this.setState({ greeting: 'bye' });",
+						"this.setState({ greeting: 'hello' });"
+					)
+				);
+				await timeout(1000);
+
+				await button.click();
+				await expectByPolling(() => getText(text), 'hello');
+			});
+		}
 	});
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -151,7 +151,7 @@ integrations.forEach(integration => {
 				const text = await page.$('.class-text');
 				await expectByPolling(() => getText(text), "I'm a class component");
 
-				await updateFile('src/class.jsx', content =>
+				await updateFile('src/greeting.jsx', content =>
 					content.replace(
 						"I'm a class component",
 						"I'm a reloaded class component"
@@ -173,7 +173,7 @@ integrations.forEach(integration => {
 				await button.click();
 				await expectByPolling(() => getText(text), 'bye');
 
-				await updateFile('src/class.jsx', content =>
+				await updateFile('src/greeting.jsx', content =>
 					content.replace(
 						"this.setState({ greeting: 'bye' });",
 						"this.setState({ greeting: 'hello' });"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -160,7 +160,7 @@ integrations.forEach(integration => {
 				await timeout(1000);
 
 				await expectByPolling(
-					() => getText(value),
+					() => getText(text),
 					"I'm a reloaded class component"
 				);
 			});


### PR DESCRIPTION
We can make this work for exported components in Webpack, Next and Nollup, this because `react-refresh/babel` ignores class  components.

This is currently not possible in vite and snowpack due not being able to inspect current and previous exports.

We could fork the babel-plugin and implement this but no clue if we should.