### PR TITLE
[snowpack] add private class properties support

### DIFF
--- a/.changeset/smooth-files-hammer.md
+++ b/.changeset/smooth-files-hammer.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/snowpack': minor
+---
+
+Add support for class properties syntax

--- a/packages/snowpack/package.json
+++ b/packages/snowpack/package.json
@@ -45,6 +45,7 @@
 	"homepage": "https://github.com/JoviDeCroock/prefresh#readme",
 	"dependencies": {
 		"@babel/core": "^7.9.6",
+		"@babel/plugin-syntax-class-properties": "^7.10.0",
 		"@prefresh/babel-plugin": "0.2.2",
 		"@prefresh/core": "^1.0.0",
 		"@prefresh/utils": "^1.0.0"

--- a/packages/snowpack/src/index.js
+++ b/packages/snowpack/src/index.js
@@ -74,7 +74,10 @@ export default function preactRefreshPlugin(config, pluginOptions) {
 
 const transform = (code, id) =>
 	transformSync(code, {
-		plugins: [[require('@prefresh/babel-plugin'), { skipEnvCheck: true }]],
+		plugins: [
+			[require('@prefresh/babel-plugin'), { skipEnvCheck: true }],
+			[require('@babel/plugin-syntax-class-properties')]
+		],
 		cwd: process.cwd(),
 		filename: id,
 		ast: false,


### PR DESCRIPTION
We've gotten a request to support private class properties, which works in Snowpack but not in this plugin: https://github.com/pikapkg/snowpack/issues/1263

This proposal is in stage 3, which means it's already being shipped in browsers and supported in many of them already: https://caniuse.com/mdn-javascript_classes_private_class_fields

Hopefully this is merged into babel proper soon, but for now this is the official way to enable.