### PR TITLE
Fix @prefresh/next defaultLoaders assignment

### DIFF
--- a/.changeset/unlucky-apples-hear.md
+++ b/.changeset/unlucky-apples-hear.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/next': patch
+---
+
+Fix assignment of defaultLoaders

--- a/packages/next/src/index.js
+++ b/packages/next/src/index.js
@@ -21,9 +21,6 @@ module.exports = (nextConfig = {}) => {
 
 				config.plugins.unshift(new Prefresh({ runsInNextJs: true }));
 
-				const copyLoader = { ...defaultLoaders.babel };
-				const copyLoaderOptions = { ...defaultLoaders.babel.options };
-
 				defaultLoaders.babel.options.plugins = [].slice.call(
 					defaultLoaders.babel.options.plugins || []
 				);
@@ -34,10 +31,6 @@ module.exports = (nextConfig = {}) => {
 				]);
 
 				defaultLoaders.babel.options.hasReactRefresh = false;
-
-				// This prevents the overrides above from affecting the server:
-				copyLoader.options = copyLoaderOptions;
-				defaultLoaders.babel = copyLoader;
 			}
 
 			if (typeof nextConfig.webpack === 'function') {


### PR DESCRIPTION
The assignment of `defaultLoaders` is undone with `copyLoader`. [Source](https://github.com/JoviDeCroock/prefresh/blob/909fcd105bdf813e4c0a5aad7814a5ec9e02ffe3/packages/next/src/index.js#L40).

`copyLoader` and `copyLoaderOptions` are new objects, so any changes made to `defaultLoaders` are removed when `defaultLoaders = copyLoader` occurs.

More importantly, the intention of the code is not needed since NextJS creates a new `defaultLoaders` object ([Source](https://github.com/vercel/next.js/blob/3f07e554f4347240bf594f801e5de0499413f8ab/packages/next/build/webpack-config.ts#L241-L262)) for every [build target](https://github.com/vercel/next.js/blob/c351f6154bcc31b2261497a925ebc67a5ef4e076/packages/next/server/hot-reloader.ts#L301-L319). E.g: server, client.
