### PR TITLE
Nollup: Add ES module wrapper

### DIFF
--- a/.changeset/afraid-ties-fail.md
+++ b/.changeset/afraid-ties-fail.md
@@ -1,0 +1,5 @@
+---
+"@prefresh/nollup": patch
+---
+
+Add `.mjs` export for compatability with newer Node versions

--- a/packages/nollup/package.json
+++ b/packages/nollup/package.json
@@ -2,6 +2,7 @@
 	"name": "@prefresh/nollup",
 	"version": "2.0.0",
 	"main": "src/index.js",
+	"module": "src/wrapper.mjs",
 	"exports": {
 		".": {
 			"require": "./src/index.js",

--- a/packages/nollup/package.json
+++ b/packages/nollup/package.json
@@ -4,7 +4,8 @@
 	"main": "src/index.js",
 	"exports": {
 		".": {
-			"require": "./src/index.js"
+			"require": "./src/index.js",
+			"import": "./src/wrapper.mjs"
 		},
 		"./package.json": "./package.json",
 		"./": "./"

--- a/packages/nollup/src/wrapper.mjs
+++ b/packages/nollup/src/wrapper.mjs
@@ -1,0 +1,3 @@
+// Re-export as ES6
+// See https://nodejs.org/dist/latest-v14.x/docs/api/packages.html#packages_approach_1_use_an_es_module_wrapper
+export { default } from './index.js';


### PR DESCRIPTION
When using rollup configuration in in [ES module/ untranspiled mode](https://rollupjs.org/guide/en/#using-untranspiled-config-files), it's not possible to import `@prefresh/nollup` plugin.

```js
// rollup.config.mjs

import nollupPluginPrefresh from '@prefresh/nollup'
```

Produces
```
[!] Error: No "exports" main defined in xxx\node_modules\@prefresh\nollup\package.json imported from xxx\rollup.config.mjs
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in xxx\node_modules\@prefresh\nollup\package.json imported from xxx\rollup.config.mjs
```

I've added an mjs wrapper as described in node.js docs [here](https://nodejs.org/dist/latest-v14.x/docs/api/packages.html#packages_approach_1_use_an_es_module_wrapper).

Follow up to https://github.com/JoviDeCroock/prefresh/pull/69