### PR TITLE
fix runtime node module resolve error

### DIFF
--- a/.changeset/late-boats-shake.md
+++ b/.changeset/late-boats-shake.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/nollup': patch
+---
+
+fix runtime node module resolve error. it's necessary to use an explicit extension when import if there's an exports path field in pacakge.json

--- a/packages/nollup/src/index.js
+++ b/packages/nollup/src/index.js
@@ -44,7 +44,7 @@ module.exports = function() {
 			return {
 				code: [
 					code,
-					'import { __$RefreshCheck$__ } from "@prefresh/nollup/src/runtime"',
+					'import { __$RefreshCheck$__ } from "@prefresh/nollup/src/runtime.js"',
 					'__$RefreshCheck$__(module)'
 				].join(';')
 			};


### PR DESCRIPTION
According to https://github.com/rollup/plugins/issues/684, it's necessary to use an explicit extension when import if there's an `exports` path field in `pacakge.json`.
If not adding `.js` extension, it will fail to build when using `@rollup/plugin-node-resolve@^11.0.0`.