### PR TITLE
(core) - map old VNodes to new ones

### DIFF
--- a/.changeset/weak-rules-sparkle.md
+++ b/.changeset/weak-rules-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/core': minor
+---
+
+Update oldVnodeTypes in place with newer equivalents

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -19,7 +19,7 @@ import {
 	HOOK_CLEANUP
 } from './constants';
 import { computeKey } from './computeKey';
-import { vnodesForComponent } from './runtime/vnodesForComponent';
+import { vnodesForComponent, mappedVNodes } from './runtime/vnodesForComponent';
 import { signaturesForType } from './runtime/signaturesForType';
 
 let typesById = new Map();
@@ -50,6 +50,8 @@ function replaceComponent(OldType, NewType, resetHookState) {
 	// migrate the list to our new constructor reference
 	vnodesForComponent.delete(OldType);
 	vnodesForComponent.set(NewType, vnodes);
+
+	mappedVNodes.set(OldType, NewType);
 
 	pendingUpdates = pendingUpdates.filter(p => p[0] !== OldType);
 

--- a/packages/core/src/runtime/vnode.js
+++ b/packages/core/src/runtime/vnode.js
@@ -1,5 +1,14 @@
 import { options } from 'preact';
-import { vnodesForComponent } from './vnodesForComponent';
+import { vnodesForComponent, mappedVNodes } from './vnodesForComponent';
+import { VNODE_COMPONENT } from '../constants';
+
+const getMappedVnode = type => {
+	if (mappedVNodes.has(type)) {
+		return getMappedVnode(mappedVNodes.get(type));
+	}
+
+	return type;
+};
 
 const oldVnode = options.vnode;
 options.vnode = vnode => {
@@ -9,6 +18,12 @@ options.vnode = vnode => {
 			vnodesForComponent.set(vnode.type, [vnode]);
 		} else {
 			vnodes.push(vnode);
+		}
+
+		const foundType = getMappedVnode(vnode.type);
+		vnode.type = foundType;
+		if (vnode[VNODE_COMPONENT]) {
+			vnode[VNODE_COMPONENT].constructor = foundType;
 		}
 	}
 

--- a/packages/core/src/runtime/vnodesForComponent.js
+++ b/packages/core/src/runtime/vnodesForComponent.js
@@ -1,2 +1,3 @@
 // all vnodes referencing a given constructor
 export const vnodesForComponent = new WeakMap();
+export const mappedVNodes = new WeakMap();


### PR DESCRIPTION
This was kindly reported by @iFwu this is the second part of this bug-report https://github.com/iFwu/prefresh-bugs-reproduce

This mainly happens in esm-hmr, let's visualize what's happening here, information about [esm-hmr can be found here](https://github.com/snowpackjs/esm-hmr).

When we update `Counter.jsx`, the child of `Internal.jsx` we do the following implicitly `import Counter.jsx?mtime=Date.now()` this will make our babel-functions re-run and register the new type for `Counter.jsx`. For in place updates this works great, but when we now update `Internal.jsx` we'll be importing the old variant of `Counter.jsx` since during esm-hmr we have no way to update this `ModuleRecord` in place, essentially the `Counter.jsx?mtime=Date.now()` is orphaned and disposed instantly.

`internal.jsx` updates with the old reference, without checking for a new one to exist (byte-cache), this makes it render with the initial code rather than the new.

We've solved this by keeping a mapping of old to new functional components, when we see a vnode created with a supposedly old reference we update it to the new one.