### PR TITLE
Fix exception in isComponent when exportValue is undefined

### DIFF
--- a/.changeset/sour-olives-fry.md
+++ b/.changeset/sour-olives-fry.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/utils': patch
+---
+
+Fix exception in isComponent when exportValue is undefined

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -26,7 +26,6 @@ export const flush = () => {
 };
 
 export const isComponent = exportValue => {
-  const name = exportValue.name || exportValue.displayName;
   if (typeof exportValue === 'function') {
     if (
       exportValue.prototype != null &&
@@ -34,6 +33,8 @@ export const isComponent = exportValue => {
     ) {
       return true;
     }
+
+    const name = exportValue.name || exportValue.displayName;
     return (
       typeof name === 'string' && name[0] && name[0] == name[0].toUpperCase()
     );


### PR DESCRIPTION
Exception:
```
webpack-internal:///./node_modules/next/dist/client/next-dev.js:97 Error was not caught TypeError: Cannot read property 'name' of undefined
    at isComponent (webpack-internal:///./node_modules/@prefresh/utils/src/index.js:32)
    at Object.shouldBind (webpack-internal:///./node_modules/@prefresh/webpack/src/utils/prefresh.js:25)
    at Module.eval (webpack-internal:///./src/shared/utils/constants.js:226)
    at eval (webpack-internal:///./src/shared/utils/constants.js:253)
    at Module../src/shared/utils/constants.js (_app.js:2004)
```