### PR TITLE
Remove redundant peerDependencies

### DIFF
--- a/.changeset/empty-islands-guess.md
+++ b/.changeset/empty-islands-guess.md
@@ -1,0 +1,5 @@
+---
+"@prefresh/snowpack": patch
+---
+
+Remove redundant `@prefresh/babel-plugin` dependency

--- a/packages/snowpack/package.json
+++ b/packages/snowpack/package.json
@@ -56,7 +56,6 @@
     "snowpack": "^2.0.0"
   },
   "peerDependencies": {
-    "@prefresh/babel-plugin": "^0.4.0",
     "preact": "^10.4.0",
     "snowpack": "^2.0.0"
   }


### PR DESCRIPTION
Remove redundant peerDependencies:

- `@prefetch/babel-plugin` because it's already in `dependencies`.

It helps avoid incorrect warnings when installing packages.