### PR TITLE
(snowpack) - avoid running in ssr

### DIFF
--- a/.changeset/small-turtles-kneel.md
+++ b/.changeset/small-turtles-kneel.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/snowpack': patch
+---
+
+Avoid running in `snowpack@3.0.0` SSR mode

--- a/packages/snowpack/src/index.js
+++ b/packages/snowpack/src/index.js
@@ -6,8 +6,13 @@ export default function preactRefreshPlugin(config, pluginOptions) {
       '@prefresh/snowpack/runtime',
       '@prefresh/snowpack/utils',
     ],
-    async transform({ contents, urlPath, isDev, id }) {
-      if (!isDev || !urlPath.endsWith('.js') || config.devOptions.hmr === false)
+    async transform({ contents, urlPath, isDev, isSSR, id }) {
+      if (
+        isSSR ||
+        !isDev ||
+        !urlPath.endsWith('.js') ||
+        config.devOptions.hmr === false
+      )
         return;
 
       let hasRefeshReg = /\$RefreshReg\$\(/.test(contents);


### PR DESCRIPTION
👋🏻  Hey @JoviDeCroock! I'm working on improving Microsite's dev mode SSR features.

It looks like `@prefresh/snowpack` doesn't check `isSSR` before running `transform`. `isSSR` is decoupled from `isDev` so this is causing some issues when both are `true`.