### PR TITLE
Support Snowpack 3 in @prefresh/snowpack

### DIFF
--- a/.changeset/chatty-knives-join.md
+++ b/.changeset/chatty-knives-join.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/snowpack': minor
+---
+
+Add support for Snowpack 3

--- a/packages/snowpack/package.json
+++ b/packages/snowpack/package.json
@@ -57,6 +57,6 @@
   },
   "peerDependencies": {
     "preact": "^10.4.0",
-    "snowpack": "^2.0.0"
+    "snowpack": "^2.0.0 || ^3.0.0"
   }
 }


### PR DESCRIPTION
Changes `snowpack` peer dependency version to allow version 3 in addition to version 2.