### PR TITLE
feat: exclude prefresh internals from dep optimization

### DIFF
--- a/.changeset/new-apples-bow.md
+++ b/.changeset/new-apples-bow.md
@@ -1,0 +1,5 @@
+---
+"@prefresh/vite": patch
+---
+
+exclude prefresh internals from dep optimization

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -7,6 +7,16 @@ export default function prefreshPlugin() {
   let shouldSkip = false;
   return {
     name: 'prefresh',
+    config() {
+      return {
+        optimizeDeps: {
+          exclude: [
+            '@prefresh/vite/runtime',
+            '@prefresh/vite/utils'
+          ]
+        }
+      }
+    },
     configResolved(config) {
       shouldSkip = config.command === 'build' || config.isProduction;
     },


### PR DESCRIPTION
vite now auto-discovers imported dependencies even from transformed
code. Without the exclude here it still works, but the explicit exclude
avoids vite from re-bundling deps upon server start.