### PR TITLE
Add IE11 support to @prefresh/webpack

### DIFF
--- a/.changeset/young-taxis-arrive.md
+++ b/.changeset/young-taxis-arrive.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/webpack': minor
+---
+
+Support IE11 in development mode

--- a/README.md
+++ b/README.md
@@ -44,3 +44,20 @@ export default Refresh;
 
 When you are working with HOC's be sure to lift up the `displayName` so we can
 recognise it as a component.
+
+## Usage in IE11
+
+If you want to use `@prefresh/webpack` or `@prefresh/next` with IE11, you'll need to transpile the `@prefresh/core` and `@prefresh/utils` packages.
+
+For Next.js you can install `next-transpile-modules` and add the following code snippet to your `next.config.js`.
+
+```js
+const withTranspiledModules = require('next-transpile-modules')([
+  '@prefresh/core',
+  '@prefresh/utils',
+]);
+
+module.exports = withTM({
+  /* regular next.js config options here */
+});
+```

--- a/packages/webpack/src/loader/runtime.js
+++ b/packages/webpack/src/loader/runtime.js
@@ -19,7 +19,7 @@ module.exports = function () {
       }
     }
 
-    module.hot.dispose(function (data) {
+    module.hot.dispose(data => {
       data.moduleExports = __prefresh_utils__.getExports(module);
     });
 

--- a/packages/webpack/src/utils/createTemplate.js
+++ b/packages/webpack/src/utils/createTemplate.js
@@ -3,20 +3,20 @@ const { Template } = require('webpack');
 const NAMESPACE = '__PREFRESH__';
 
 const beforeModule = `
-const prevRefreshReg = self.$RefreshReg$;
-const prevRefreshSig = self.$RefreshSig$;
+var prevRefreshReg = self.$RefreshReg$;
+var prevRefreshSig = self.$RefreshSig$;
 
-self.$RefreshSig$ = () => {
-  let status = 'begin';
-  let savedType;
-  return (type, key, forceReset, getCustomHooks) => {
+self.$RefreshSig$ = function() {
+  var status = 'begin';
+  var savedType;
+  return function(type, key, forceReset, getCustomHooks) {
     if (!savedType) savedType = type;
     status = self.${NAMESPACE}.sign(type || savedType, key, forceReset, getCustomHooks, status);
     return type;
   };
 };
 
-self.$RefreshReg$ = (type, id) => {
+self.$RefreshReg$ = function(type, id) {
   self.${NAMESPACE}.register(type, module.i + ' ' + id);
 };
 


### PR DESCRIPTION
This PR updates `@prefresh/webpack` to inject ES5 template code into the webpack bundle that is served to browsers during HMR.

This change alone will not allow development in IE 11 to work, @prefresh/core and @prefresh/utils both need to be transpiled by the user. I've added a note in the README detailing this.

Fixes #277 