### PR TITLE
Add package support

### DIFF
--- a/packages/snowpack/src/index.js
+++ b/packages/snowpack/src/index.js
@@ -3,13 +3,15 @@ import prefreshBabelPlugin from '@prefresh/babel-plugin';
 
 export default function preactRefreshPlugin(config, pluginOptions) {
   return {
+    name: '@prefresh/snowpack',
     knownEntrypoints: [
       '@prefresh/snowpack/runtime',
       '@prefresh/snowpack/utils',
     ],
-    async transform({ contents, urlPath, isDev, isSSR, id }) {
+    async transform({ contents, urlPath, isDev, isPackage, isSSR, id }) {
       if (
         isSSR ||
+        isPackage ||
         !isDev ||
         !urlPath.endsWith('.js') ||
         config.devOptions.hmr === false


### PR DESCRIPTION
- Snowpack v3.1 adds the ability for plugins to run on `node_module/*` dependencies
- This caused trouble for prefresh, which breaks if it runs on Preact itself
- We made a quick fix in Snowpack to make sure that existing users weren't effected. 
- This PR skips HMR support on any `node_module/*` dependency files, using the `isPackage` check

/cc @JoviDeCroock 