### PR TITLE
fix(vite): compatibility issues with pnpm

### DIFF
--- a/.changeset/fuzzy-squids-explode.md
+++ b/.changeset/fuzzy-squids-explode.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/vite': patch
+---
+
+Fix compatibility issues with pnpm (#328)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prefresh",
   "scripts": {
-    "build": "yarn workspace @prefresh/web-dev-server build && yarn workspace @prefresh/snowpack build && yarn workspace @prefresh/vite build && yarn workspace @prefresh/utils build && yarn workspace @prefresh/babel-plugin build",
+    "build": "yarn workspace @prefresh/web-dev-server build && yarn workspace @prefresh/snowpack build && yarn workspace @prefresh/utils build && yarn workspace @prefresh/babel-plugin build",
     "lint": "eslint src",
     "test": "jest --clearCache && jest --runInBand --forceExit --detectOpenHandles",
     "changeset": "changeset",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@prefresh/vite",
   "version": "2.2.1",
-  "module": "dist/index.mjs",
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "types": "index.d.ts",
   "exports": {
     ".": "./src/index.js",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -5,10 +5,7 @@
   "main": "dist/index.js",
   "types": "index.d.ts",
   "exports": {
-    ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
-    },
+    ".": "./src/index.js",
     "./package.json": "./package.json",
     "./": "./"
   },
@@ -22,7 +19,6 @@
     "index.d.ts"
   ],
   "scripts": {
-    "build": "bundt",
     "lint": "eslint src",
     "test": "jest --clearCache && jest --runInBand --forceExit --detectOpenHandles"
   },
@@ -44,7 +40,6 @@
     "@rollup/pluginutils": "^4.1.0"
   },
   "devDependencies": {
-    "bundt": "^1.1.1",
     "preact": "^10.5.7",
     "vite": "^2.0.0-beta.3"
   },

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -9,21 +9,11 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
-    "./runtime": {
-      "import": "./runtime/index.mjs",
-      "require": "./runtime/index.js"
-    },
-    "./utils": {
-      "import": "./utils/index.mjs",
-      "require": "./utils/index.js"
-    },
     "./package.json": "./package.json",
     "./": "./"
   },
   "modes": {
-    "default": "src/index.js",
-    "runtime": "src/runtime.js",
-    "utils": "src/utils.js"
+    "default": "src/index.js"
   },
   "files": [
     "dist",

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -38,8 +38,8 @@ module.exports = function prefreshPlugin(options = {}) {
 
       if (!hasSig && !hasReg) return code;
 
-      const prefreshCore = await this.resolve('@prefresh/core', __filename); // fixme: use import.meta.url for the mjs output
-      const prefreshUtils = await this.resolve('@prefresh/utils', __filename); // fixme: use import.meta.url for the mjs output
+      const prefreshCore = await this.resolve('@prefresh/core', __filename);
+      const prefreshUtils = await this.resolve('@prefresh/utils', __filename);
 
       const prelude = `
         ${'import'} ${JSON.stringify(prefreshCore.id)};

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -12,7 +12,7 @@ export default function prefreshPlugin(options = {}) {
     configResolved(config) {
       shouldSkip = config.command === 'build' || config.isProduction;
     },
-    transform(code, id, ssr) {
+    async transform(code, id, ssr) {
       if (
         shouldSkip ||
         !/\.(t|j)sx?$/.test(id) ||
@@ -38,9 +38,12 @@ export default function prefreshPlugin(options = {}) {
 
       if (!hasSig && !hasReg) return code;
 
+      const prefreshRuntime = await this.resolve('@prefresh/vite/runtime', __filename) // fixme: use import.meta.url for the mjs output
+      const prefreshUtils = await this.resolve('@prefresh/vite/utils', __filename) // fixme: use import.meta.url for the mjs output
+
       const prelude = `
-        ${'import'} '@prefresh/vite/runtime';
-        ${'import'} { flushUpdates } from '@prefresh/vite/utils';
+        ${'import'} ${JSON.stringify(prefreshRuntime.id)};
+        ${'import'} { flushUpdates } from ${JSON.stringify(prefreshUtils.id)};
 
         let prevRefreshReg;
         let prevRefreshSig;

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -1,9 +1,9 @@
-import { transformSync } from '@babel/core';
-import { createFilter } from '@rollup/pluginutils';
-import prefreshBabelPlugin from '@prefresh/babel-plugin';
+const { transformSync } = require('@babel/core');
+const { createFilter } = require('@rollup/pluginutils');
+const prefreshBabelPlugin = require('@prefresh/babel-plugin');
 
 /** @returns {import('vite').Plugin} */
-export default function prefreshPlugin(options = {}) {
+module.exports = function prefreshPlugin(options = {}) {
   let shouldSkip = false;
   const filter = createFilter(options.include, options.exclude);
 

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -38,12 +38,12 @@ export default function prefreshPlugin(options = {}) {
 
       if (!hasSig && !hasReg) return code;
 
-      const prefreshRuntime = await this.resolve('@prefresh/vite/runtime', __filename) // fixme: use import.meta.url for the mjs output
-      const prefreshUtils = await this.resolve('@prefresh/vite/utils', __filename) // fixme: use import.meta.url for the mjs output
+      const prefreshCore = await this.resolve('@prefresh/core', __filename); // fixme: use import.meta.url for the mjs output
+      const prefreshUtils = await this.resolve('@prefresh/utils', __filename); // fixme: use import.meta.url for the mjs output
 
       const prelude = `
-        ${'import'} ${JSON.stringify(prefreshRuntime.id)};
-        ${'import'} { flushUpdates } from ${JSON.stringify(prefreshUtils.id)};
+        ${'import'} ${JSON.stringify(prefreshCore.id)};
+        ${'import'} { flush as flushUpdates } from ${JSON.stringify(prefreshUtils.id)};
 
         let prevRefreshReg;
         let prevRefreshSig;

--- a/packages/vite/src/runtime.js
+++ b/packages/vite/src/runtime.js
@@ -1,1 +1,0 @@
-import '@prefresh/core';

--- a/packages/vite/src/utils.js
+++ b/packages/vite/src/utils.js
@@ -1,2 +1,0 @@
-import { flush } from '@prefresh/utils';
-export const flushUpdates = flush;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3308,16 +3308,6 @@ bundt@^1.0.1:
     rewrite-imports "^2.0.0"
     terser "^4.6.0"
 
-bundt@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/bundt/-/bundt-1.1.1.tgz#c7beb5d806c1b5160bbdd476f1e1544cbc5f04b5"
-  integrity sha512-x3GRBxMMgcd+EfkyrLxBOg+gbM6ivnjSWZAmUX9RpTOx9Jv5VLu8l7ZbxSnP09BpVMT+qlgw19FCamUwOX4cxg==
-  dependencies:
-    kleur "^4.0.0"
-    mk-dirs "^3.0.0"
-    rewrite-imports "^2.0.0"
-    terser "^4.8.0"
-
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -7450,11 +7440,6 @@ kleur@^3.0.1, kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-kleur@^4.0.0:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.3.tgz#8d262a56d79a137ee1b706e967c0b08a7fef4f4c"
-  integrity sha512-H1tr8QP2PxFTNwAFM74Mui2b6ovcY9FoxJefgrwxY+OCJcq01k5nvhf4M/KnizzrJvLRap5STUy7dgDV35iUBw==
-
 koa-compose@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-3.2.1.tgz#a85ccb40b7d986d8e5a345b3a1ace8eabcf54de7"
@@ -8088,11 +8073,6 @@ mk-dirs@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mk-dirs/-/mk-dirs-1.0.0.tgz#44ee67f82341c6762718e88e85e577882e1f67fd"
   integrity sha1-RO5n+CNBxnYnGOiOheV3iC4fZ/0=
-
-mk-dirs@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/mk-dirs/-/mk-dirs-3.0.0.tgz#1a0296e04ae5c2e5063db4089907efbdff79b7c4"
-  integrity sha512-FEZDdUFb88hgdnsfAPa4VxcPVOd+8GyZ2jsI965im5bjBlBYhrvXuTqLka/UHa6YdUNN/kZBsVgofhZ3322AJw==
 
 mkdirp-classic@^0.5.2:
   version "0.5.3"
@@ -11261,15 +11241,6 @@ terser@^4.1.2, terser@^4.6.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.7.0.tgz#15852cf1a08e3256a80428e865a2fa893ffba006"
   integrity sha512-Lfb0RiZcjRDXCC3OSHJpEkxJ9Qeqs6mp2v4jf2MHfy8vGERmVDuvjXdd/EnP5Deme5F2yBRBymKmKHCBg2echw==
-  dependencies:
-    commander "^2.20.0"
-    source-map "~0.6.1"
-    source-map-support "~0.5.12"
-
-terser@^4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
-  integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
Passes `@prefresh/vite/runtime` and `@prefresh/vite/utils` through rollup's resolve logic, to avoid package visibility issues occurring when using pnpm

Support for mjs is not accounted for yet, I'm struggling a bit with using `import.meta.url` only in the bundled .mjs file, as bundt doesn't transform this and keeps it as-is.

fixes #328